### PR TITLE
disallow spaces after object keys

### DIFF
--- a/.jscsrc
+++ b/.jscsrc
@@ -18,6 +18,7 @@
 	"disallowSpacesInsideObjectBrackets": true,
 	"disallowSpacesInsideArrayBrackets": true,
 	"disallowSpacesInsideParentheses": true,
+	"disallowSpaceAfterObjectKeys": true,
 	"disallowSpaceAfterPrefixUnaryOperators": [
 		"++",
 		"--",

--- a/test/files/bad/test_bad.js
+++ b/test/files/bad/test_bad.js
@@ -101,6 +101,11 @@ var x = ( 1 + 2 );
 var x = foo( {} );
 */
 
+// We disallowSpaceAfterObjectKeys
+/* BAD
+var x = {a : 1};
+*/
+
 // We disallowSpaceAfterPrefixUnaryOperators
 /* BAD
 x = ! a;

--- a/test/files/good/test_perfect.js
+++ b/test/files/good/test_perfect.js
@@ -108,6 +108,9 @@ x = [[1]];
 // We disallowSpacesInsideParentheses
 x = (1 + 2) * 3;
 
+// We disallowSpaceAfterObjectKeys
+x = {a: 1};
+
 // We disallowSpaceAfterPrefixUnaryOperators
 x = !a;
 b = ++c;


### PR DESCRIPTION
Enabled the `disallowSpaceAfterObjectKeys` `jscs` option to register extra spaces after keys in object literals as invalid.

For example:
- `{a : 1}` - invalid
- `{a: 1}` - valid
