### PR TITLE
disallow multiple spaces between tokens except before line comments

### DIFF
--- a/.jscsrc
+++ b/.jscsrc
@@ -3,6 +3,7 @@
 	"disallowKeywords": [
 		"with"
 	],
+	"disallowMultipleSpaces": {"allowEOLComments": true},
 	"disallowMultipleVarDecl": "exceptUndefined",
 	"disallowMixedSpacesAndTabs": true,
 	"disallowMultipleLineBreaks": true,

--- a/test/files/bad/test_bad.js
+++ b/test/files/bad/test_bad.js
@@ -1,5 +1,10 @@
 'use strict';
 
+// We disallowMultipleSpaces, except before line comments
+/* BAD
+var x = { omg:       'I\'m floating awaaaay...' };
+*/
+
 // We disallowMultipleVarDecl exceptUndefined
 /* BAD
 var

--- a/test/files/good/test_perfect.js
+++ b/test/files/good/test_perfect.js
@@ -3,6 +3,9 @@
 // comments can begin with an lowercase
 // Or an uppercase letter
 
+// We disallowMultipleSpaces, except before line comments
+var look = 'at all the silly spaces';        // before this comment
+
 // We disallowMultipleVarDecl exceptUndefined
 var a, b, c, d;
 var x = 'example';


### PR DESCRIPTION
Kind of expected this to have been set already. Should prevent stuff like:

```
x = {
    x: 'one',
    y:  'two',
    z: 'three'
};
```
