### PR TITLE
Bumped up grunt-contrib-jshint version to 1.0.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
   },
   "dependencies": {
     "lodash": "^3.5.0",
-    "grunt-contrib-jshint": "^0.11.0",
+    "grunt-contrib-jshint": "^1.0.0",
     "grunt-jscs": "^2.3.0",
     "grunt-lintspaces": "^0.7.1"
   },

--- a/test/files/good/test_perfect.js
+++ b/test/files/good/test_perfect.js
@@ -12,13 +12,7 @@ var a, b, c, d;
 var x = 'example';
 var y = 'another';
 
-// Just going to call this example so jshint doesn't complain
-a();
-
 // We disallowEmptyBlocks except for catch blocks
-if (a == b) {
-	c = d;
-}
 try {
 	a = b;
 }
@@ -52,9 +46,7 @@ function good() {
 		data: obj
 	};
 }
-
-// Just going to call this example so jshint doesn't complain
-good();
+good();  // call to kill jshint warning
 
 // We disallowOperatorBeforeLineBreak ?", "||", "."
 var chainable = {
@@ -84,7 +76,7 @@ switch (b) {
 
 // We disallowPaddingNewlinesInBlocks
 if (true) {
-	a();
+	a = a;
 }
 
 // We disallowQuotedKeysInObjects
@@ -94,7 +86,7 @@ x = {
 
 // We disallowSpacesInNamedFunctionExpression beforeOpeningRoundBrace
 x = function d() {
-	a();
+	a = a;
 };
 
 // We disallowSpacesInsideObjectBrackets
@@ -133,14 +125,13 @@ x = a++;
 b = c--;
 
 // We disallowSpacesInCallExpression
-x = a();
-
 // We disallowSpacesInFunctionDeclaration beforeOpeningRoundBrace
 // We disallowSpacesInNamedFunctionExpression beforeOpeningRoundBrace
 // We requireSpacesInFunctionDeclaration beforeOpeningCurlyBrace
 // We requireSpacesInNamedFunctionExpression beforeOpeningCurlyBrace
-function a() {}
-a();
+function f() {}
+x = f();
+f();
 
 // We disallowTrailingWhitespace ignoreEmptyLines
 
@@ -157,7 +148,7 @@ if (a == 1) {
 
 // We requireBlocksOnNewline
 if (true) {
-	a();
+	f();
 }
 
 // We requireCamelCaseOrUpperCaseIdentifiers ignoreProperties
@@ -217,7 +208,7 @@ b !== c;
 
 // We requireSpaceBeforeBlockStatements
 if (true) {
-	a();
+	f();
 }
 else {
 	b = c;
@@ -229,7 +220,7 @@ b = {
 };
 
 // We requireSpaceBetweenArguments
-a(b, c);
+f(b, c);
 
 // We requireSpacesInConditionalExpression
 a = b ? c : d;
@@ -265,10 +256,10 @@ if (true) {
 }
 
 // We validateParameterSeparator ', '
-function a(b, c) {
+function g(b, c) {
 	b = c;
 }
-a();
+g();  // call to kill jshint warning
 
 // We validateQuoteMarks
 b = 'string with "single" quotes only';


### PR DESCRIPTION
This avoids the dependency on the mis-designed colors package that can cause
mysterious failures in case it gets used in combination with certain karma
versions (unless we are really careful about the order in which some related
npm packages get loaded).

See related issue at:
https://github.com/gruntjs/grunt-contrib-jshint/issues/237

In addition updated the `test_perfect.js` test/example script to make it pass the
latest `jshint` version checks.
